### PR TITLE
Render priorityClassName in the openclaw deployment

### DIFF
--- a/charts/openclaw/Chart.yaml
+++ b/charts/openclaw/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: openclaw
 description: OpenClaw AI assistant — gateway with persistent workspace and optional MCP sidecars
 type: application
-version: 0.2.0
+version: 0.3.0
 # renovate datasource=docker depName=ghcr.io/openclaw/openclaw versioning=docker
 appVersion: 'main-slim'

--- a/charts/openclaw/templates/deployment.yaml
+++ b/charts/openclaw/templates/deployment.yaml
@@ -197,6 +197,9 @@ spec:
       dnsConfig:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/openclaw/values.yaml
+++ b/charts/openclaw/values.yaml
@@ -224,6 +224,9 @@ resources:
     memory: 2Gi
     cpu: '1'
 
+# Pod priority class. Empty means the cluster default (globalDefault or priority 0).
+priorityClassName: ''
+
 nodeSelector: {}
 tolerations: []
 affinity: {}


### PR DESCRIPTION
The homelab values have been setting priorityClassName since the chart was adopted, but the pod template never emitted the field, so the setting was silently dropped and the gateway ran at the cluster default priority. It now renders when set and is omitted otherwise, so charts that leave it empty are unaffected.

Bumped to 0.3.0 so consumers can pick it up.